### PR TITLE
Load CSS relative to script location if possible

### DIFF
--- a/butterpop.esm.js
+++ b/butterpop.esm.js
@@ -551,12 +551,12 @@ const injectCSS = () => {
   // Check if CSS already exists
   if (elementExists('style[data-butterpop-css]')) return;
   
-  // Try to load the CSS file
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = 'https://cdn.jsdelivr.net/npm/butterpop@1.0.4/butterpop.min.css';
-  link.setAttribute('data-butterpop-css', 'true');
-  document.head.appendChild(link);
+    // Try to load the CSS file
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = selfScriptUrl ? new URL('./butterpop.css', selfScriptUrl).href : 'butterpop.css';
+    link.setAttribute('data-butterpop-css', 'true');
+    document.head.appendChild(link);
   
   // Fallback: if CSS can't be loaded, add basic inline styles
   link.onerror = () => {

--- a/butterpop.js
+++ b/butterpop.js
@@ -82,6 +82,24 @@
   
   // Global configuration
   let globalConfig = { ...DEFAULT_CONFIG };
+
+  const selfScriptUrl = (() => {
+    if (typeof document === 'undefined') return '';
+
+    const current = document.currentScript;
+    if (current && current.src) return current.src;
+
+    const scripts = document.getElementsByTagName('script');
+    for (let i = scripts.length - 1; i >= 0; i--) {
+      const src = scripts[i].getAttribute('src') || scripts[i].src;
+      if (!src) continue;
+
+      const abs = new URL(src, document.baseURI).href;
+      if (/butterpop(\.min)?\.js(\?|#|$)/.test(abs)) return abs;
+    }
+
+    return '';
+  })();
   
   // Check if an element exists in document
   const elementExists = (selector) => {
@@ -561,7 +579,7 @@
     // Try to load the CSS file
     const link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = 'https://cdn.jsdelivr.net/npm/butterpop@1.0.4/butterpop.min.css';
+    link.href = selfScriptUrl ? new URL('./butterpop.css', selfScriptUrl).href : 'butterpop.css';
     link.setAttribute('data-butterpop-css', 'true');
     document.head.appendChild(link);
     


### PR DESCRIPTION
Updated the CSS injection logic to load butterpop.css relative to the script's URL when available, instead of always using the CDN. This improves compatibility for self-hosted or local deployments.